### PR TITLE
Fixed display of duration in video list that showed minutes as seconds

### DIFF
--- a/default.py
+++ b/default.py
@@ -180,7 +180,6 @@ def listVideos(url):
         date = item['taken_time']
         thumb = item['thumbnail_large_url']
         views = item['views_total']
-        duration = str(int(duration)/60+1)
         try:
             date = datetime.datetime.fromtimestamp(int(date)).strftime('%Y-%m-%d')
         except:


### PR DESCRIPTION
The "duration" response value (in seconds) fetched from DailyMotion's search API was divided by 60, which made the video list item incorrectly show a 42 minute video as being 42 seconds.

Before fix, displayed as `00:41`:
![Before fix](https://user-images.githubusercontent.com/6984586/45254574-d96d4880-b37a-11e8-97e8-64886ec27e5f.png)

Actual length of `41:59` video being streamed:
![videolength](https://user-images.githubusercontent.com/6984586/45254578-e1c58380-b37a-11e8-98e0-152f51c3b2a4.png)

After fix, displayed as `41:59` in list item:
![after](https://user-images.githubusercontent.com/6984586/45254584-ef7b0900-b37a-11e8-9746-4e389b4ee2d8.png)





